### PR TITLE
LVLH frame calculation and gravity gradient torque

### DIFF
--- a/src/Orbit.jl
+++ b/src/Orbit.jl
@@ -185,11 +185,11 @@ function ECI2OrbitalPlaneFrame(elements::OrbitalElements)
 end
 
 """
-    function OrbitalPlaneFrame2RadialAngleTrack(elements::OrbitalElements, angular_velocity, time)
+    function OrbitalPlaneFrame2RadialAlongTrack(elements::OrbitalElements, angular_velocity, time)
 
-Calculates transformation matrix from OrbitalPlaneFrame to Radial Angle Track frame
+Calculates transformation matrix from OrbitalPlaneFrame to Radial Along Track frame
 """
-function OrbitalPlaneFrame2RadialAngleTrack(elements::OrbitalElements, angular_velocity, time)
+function OrbitalPlaneFrame2RadialAlongTrack(elements::OrbitalElements, angular_velocity, time)
 
     C1 = u -> begin
         [cos(u) sin(u) 0

--- a/src/Orbit.jl
+++ b/src/Orbit.jl
@@ -210,6 +210,7 @@ end
 Calculates transformation matrix from OrbitalPlaneFrame frame to LVLH
 """
 function OrbitalPlaneFrame2LVLH(C_OrbitalPlaneFrame2RadialAlongTrack)
+
     C = [  C_OrbitalPlaneFrame2RadialAlongTrack[2,:]';
           -C_OrbitalPlaneFrame2RadialAlongTrack[3,:]';
           -C_OrbitalPlaneFrame2RadialAlongTrack[1,:]']

--- a/src/Orbit.jl
+++ b/src/Orbit.jl
@@ -204,4 +204,18 @@ function OrbitalPlaneFrame2RadialAlongTrack(elements::OrbitalElements, angular_v
 
 end
 
+"""
+    function OrbitalPlaneFrame2LVLH(OrbitalPlaneFrame2RadialAlongTrack)
+
+Calculates transformation matrix from OrbitalPlaneFrame frame to LVLH
+"""
+function OrbitalPlaneFrame2LVLH(C_OrbitalPlaneFrame2RadialAlongTrack)
+    C = [  C_OrbitalPlaneFrame2RadialAlongTrack[2,:]';
+          -C_OrbitalPlaneFrame2RadialAlongTrack[3,:]';
+          -C_OrbitalPlaneFrame2RadialAlongTrack[1,:]']
+
+    return C
+
+end
+
 end

--- a/src/PlotGenerator.jl
+++ b/src/PlotGenerator.jl
@@ -120,7 +120,7 @@ end
 
 Generates animation of frame rotation as GIF figure
 """
-function frame_gif(time, Tsampling, refCoordinate, bodyCoordinateArray, Tgif = 0.4, FPS = 15)
+function frame_gif(time, Tsampling, refCoordinate, bodyCoordinateArray; Tgif = 60, FPS = 3)
 
     dataNum = size(time, 1)
     steps = round(Int, Tgif/Tsampling)

--- a/src/RigidBodyAttitudeDynamics.jl
+++ b/src/RigidBodyAttitudeDynamics.jl
@@ -89,7 +89,7 @@ calculate angular velocity at next time step using 4th order Runge-Kutta method
 function calc_angular_velocity(model::DynamicsModel, currentTime, angular_velocity::Vector, Tsampling, current_body_frame::Matrix, disturbance::Vector)
     # Update the angular velocity vector using 4th order runge kutta method
 
-    k1 = calc_differential_dynamics(model, currentTime                 , angular_velocity                      , current_body_frame, disturbance)
+    k1 = calc_differential_dynamics(model, currentTime              , angular_velocity                   , current_body_frame, disturbance)
     k2 = calc_differential_dynamics(model, currentTime + Tsampling/2, angular_velocity + Tsampling/2 * k1, current_body_frame, disturbance)
     k3 = calc_differential_dynamics(model, currentTime + Tsampling/2, angular_velocity + Tsampling/2 * k2, current_body_frame, disturbance)
     k4 = calc_differential_dynamics(model, currentTime + Tsampling  , angular_velocity + Tsampling   * k3, current_body_frame, disturbance)
@@ -158,6 +158,25 @@ function constant_torque()
 
     # Calculate constant torque
     torque_vector = [0, 0, 0.1];
+
+    return torque_vector
+end
+
+function gravity_gradient_torque(inertia, angular_velocity, nadir, q)
+
+    # Calculate gravity gradient torque
+
+    C = ECI2BodyFrame(q)
+
+    nadir_body = C * nadir
+
+    skewNadir = [
+         0 -nadir_body[3]  nadir_body[2]
+         nadir_body[3] 0  -nadir_body[1]
+        -nadir_body[2]  nadir_body[1] 0
+    ]
+
+    torque_vector = 3*angular_velocity^2 * skewNadir * inertia * nadir_body;
 
     return torque_vector
 end

--- a/src/RigidBodyAttitudeDynamics.jl
+++ b/src/RigidBodyAttitudeDynamics.jl
@@ -162,13 +162,14 @@ function constant_torque()
     return torque_vector
 end
 
-function gravity_gradient_torque(inertia, angular_velocity, nadir, q)
+function gravity_gradient_torque(inertia, orbit_angular_velocity, C_ECI2Body, C_ECI2LVLH, LVLHframe_z)
 
     # Calculate gravity gradient torque
 
-    C = ECI2BodyFrame(q)
+    # ここはECI2BodyFrameではなく，LVLH2Bodyになると思われる
+    C = C_ECI2Body * inv(C_ECI2LVLH)
 
-    nadir_body = C * nadir
+    nadir_body = C * LVLHframe_z
 
     skewNadir = [
          0 -nadir_body[3]  nadir_body[2]
@@ -176,7 +177,7 @@ function gravity_gradient_torque(inertia, angular_velocity, nadir, q)
         -nadir_body[2]  nadir_body[1] 0
     ]
 
-    torque_vector = 3*angular_velocity^2 * skewNadir * inertia * nadir_body;
+    torque_vector = 3*orbit_angular_velocity^2 * skewNadir * inertia * nadir_body;
 
     return torque_vector
 end

--- a/src/RigidBodyAttitudeDynamics.jl
+++ b/src/RigidBodyAttitudeDynamics.jl
@@ -154,9 +154,9 @@ function ECI2BodyFrame(q)
     return transformation_matrix
 end
 
-function gravity_gradient_torque()
+function constant_torque()
 
-    # Calculate gravity gradient torque
+    # Calculate constant torque
     torque_vector = [0, 0, 0.1];
 
     return torque_vector

--- a/test/src/GravityGradient.jl
+++ b/test/src/GravityGradient.jl
@@ -1,0 +1,112 @@
+using Test
+
+include("../../src/FlexibleSpacecraft.jl")
+using .FlexibleSpacecraft
+
+# Module for testing of simulation
+include("SimulationTesting.jl")
+using .SimulationTesting
+
+# Test simulation script
+@testset "Gravity-Gradient Torque" begin
+
+    # inertia matrix
+    inertia = diagm([1.0, 1.0, 2.0])
+
+    # define a circular orbit info
+    circular_orbit = Orbit.CircularOrbit(6370e+3 + 400e3, 3.986e+14)
+
+    orbit_angular_velocity = Orbit.get_angular_velocity(circular_orbit)
+
+    speed = Orbit.get_velocity(circular_orbit)
+
+    T = Orbit.get_timeperiod(circular_orbit, unit = "minute")
+
+    # Orbital elements of ISS
+    elem = Orbit.OrbitalElements(111.8195, 51.6433, 421e3, 0.0001239, 241.3032, 212.0072)
+
+    # Dynamics model (mutable struct)
+    model = RigidBodyAttitudeDynamics.DynamicsModel(inertia)
+
+    # Sampling period of simulation (second)
+    Tsampling = 1e-2
+
+    # Time length of simulation (second)
+    simulation_time = 60
+
+    # Array of time
+    time = 0:Tsampling:simulation_time
+
+    # Numbers of simulation data
+    data_num = round(Int, simulation_time/Tsampling) + 1;
+
+    # Earth-Centered frame (constant value)
+    ECI_frame = TimeLine.Coordinate(
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1]
+    )
+
+    C_ECI2OrbitalPlaneFrame = Orbit.ECI2OrbitalPlaneFrame(elem)
+
+    orbit_frame = TimeLine.Coordinate(
+    C_ECI2OrbitalPlaneFrame * ECI_frame.x,
+    C_ECI2OrbitalPlaneFrame * ECI_frame.y,
+    C_ECI2OrbitalPlaneFrame * ECI_frame.z
+    )
+
+
+    # Spacecraft-fixed frame (Body frame)
+    body_frame = TimeLine.init_coordinate_array(data_num, ECI_frame)
+
+    # Spacecraft-LVLH frame
+    spacecraft_LVLH = TimeLine.init_coordinate_array(data_num, orbit_frame)
+
+    # Angular velocity of body frame with respect to the ECI frame
+    body_angular_velocity = TimeLine.init_angular_velocity_array(data_num, [0, 0, 0])
+
+
+    quaternion = TimeLine.init_quaternion_array(data_num, [0, 0, 0, 1])
+
+    println("Begin simulation!")
+    for loopCounter = 0:data_num - 2
+
+        # Extract body fixed frame at current time step
+        currentCoordB = hcat(body_frame.x[:,loopCounter + 1] , body_frame.y[:,loopCounter + 1], body_frame.z[:,loopCounter + 1])
+
+        # update current RadialAngleTrack and LVLH frame
+        RAT = Orbit.OrbitalPlaneFrame2RadialAlongTrack(elem, orbit_angular_velocity, time[loopCounter + 1])
+        LVLH = Orbit.OrbitalPlaneFrame2LVLH(RAT)
+
+
+        spacecraft_LVLH.x[:, loopCounter + 1] = LVLH * orbit_frame.x
+        spacecraft_LVLH.y[:, loopCounter + 1] = LVLH * orbit_frame.y
+        spacecraft_LVLH.z[:, loopCounter + 1] = LVLH * orbit_frame.z
+
+        # Disturbance torque
+        disturbance = RigidBodyAttitudeDynamics.gravity_gradient_torque(inertia, orbit_angular_velocity, spacecraft_LVLH.z[:, loopCounter + 1], quaternion[:, loopCounter + 1])
+
+        body_angular_velocity[:, loopCounter + 2] = RigidBodyAttitudeDynamics.calc_angular_velocity(model, time[loopCounter + 1], body_angular_velocity[:, loopCounter + 1], Tsampling, currentCoordB, disturbance)
+
+        quaternion[:, loopCounter + 2] = RigidBodyAttitudeDynamics.calc_quaternion(body_angular_velocity[:,loopCounter + 1], quaternion[:, loopCounter + 1], Tsampling)
+
+        C = RigidBodyAttitudeDynamics.ECI2BodyFrame(quaternion[:, loopCounter + 1])
+
+        body_frame.x[:, loopCounter + 2] = C * ECI_frame.x
+        body_frame.y[:, loopCounter + 2] = C * ECI_frame.y
+        body_frame.z[:, loopCounter + 2] = C * ECI_frame.z
+
+    end
+    println("Simulation is completed!")
+
+    @test SimulationTesting.quaternion_constraint(quaternion)
+
+    fig1 = PlotGenerator.angular_velocity(time, body_angular_velocity)
+    display(fig1)
+
+
+   # fig2 = PlotGenerator.frame_gif(time, Tsampling, ECI_frame, body_frame)
+    fig2 = PlotGenerator.frame_gif(time, Tsampling, orbit_frame, spacecraft_LVLH)
+    display(fig2)
+
+end

--- a/test/src/OrbitTest.jl
+++ b/test/src/OrbitTest.jl
@@ -38,7 +38,7 @@ data_num = round(Int, T*60/60) + 1;
 spacecraft_RAT = TimeLine.init_coordinate_array(data_num, orbit_frame)
 for loopCounter = 0:data_num - 1
 
-    RAT = Orbit.OrbitalPlaneFrame2RadialAngleTrack(elem, angular_velocity, time[loopCounter + 1])
+    RAT = Orbit.OrbitalPlaneFrame2RadialAlongTrack(elem, angular_velocity, time[loopCounter + 1])
     spacecraft_RAT.x[:, loopCounter + 1] = RAT * orbit_frame.x
     spacecraft_RAT.y[:, loopCounter + 1] = RAT * orbit_frame.y
     spacecraft_RAT.z[:, loopCounter + 1] = RAT * orbit_frame.z

--- a/test/src/SimpleSpin.jl
+++ b/test/src/SimpleSpin.jl
@@ -53,7 +53,7 @@ using .SimulationTesting
         currentCoordB = hcat(body_frame.x[:,loopCounter + 1] , body_frame.y[:,loopCounter + 1], body_frame.z[:,loopCounter + 1])
 
         # Disturbance torque
-        disturbance = RigidBodyAttitudeDynamics.gravity_gradient_torque()
+        disturbance = RigidBodyAttitudeDynamics.constant_torque()
 
         angular_velocity[:, loopCounter + 2] = RigidBodyAttitudeDynamics.calc_angular_velocity(model, time[loopCounter + 1], angular_velocity[:, loopCounter + 1], Tsampling, currentCoordB, disturbance)
 


### PR DESCRIPTION
- I defined LVLH frame using Radial Along Track frame in `Orbit.OrbitalPlaneFrame2LVLH(C_OrbitalPlaneFrame2RadialAlongTrack)` .
- I implemented function which calculates gravity gradient torque using an nadir vector from LVLH frame in `RigidBodyAttitudeDynamics.gravity_gradient_torque`.
- I replaced previous `gravity gradient torque()` calculate function into `constant torque()`.
- I made an another `script test/src/GravityGradient.jl` which tests gravity gradient torque.
- I renamed _Radial Angle Track_ to _Radial Along Track_.

Please check it up.
Hope these changes are useful to you.