### PR TITLE
Add submodule `Evaluation.jl` for simulation evaluation

### DIFF
--- a/src/AttitudeDynamics/Evaluation.jl
+++ b/src/AttitudeDynamics/Evaluation.jl
@@ -1,8 +1,10 @@
-module SimulationTesting
+"""
+    module Evaluation
 
-include("../src/FlexibleSpacecraft.jl")
-using .FlexibleSpacecraft
-using Test
+Functions and APIs for the evaluation of the simulation result. Checking the constraints and the necessary evaluation on the simulation.
+"""
+module Evaluation
+
 using StructArrays
 using StaticArrays
 

--- a/src/FlexibleSpacecraft.jl
+++ b/src/FlexibleSpacecraft.jl
@@ -24,6 +24,9 @@ include("Disturbances/Disturbance.jl")
 include("AttitudeDynamics/RigidBody.jl")
 @reexport using .RigidBody
 
+include("AttitudeDynamics/Evaluation.jl")
+@reexport using .Evaluation
+
 # Include module `PlotRecipe`
 include("PlotRecipes/PlotRecipe.jl")
 @reexport using .PlotRecipe

--- a/test/main.jl
+++ b/test/main.jl
@@ -3,10 +3,6 @@ using Test
 include("../src/FlexibleSpacecraft.jl")
 using .FlexibleSpacecraft
 
-# Module for testing of simulation
-include("SimulationTesting.jl")
-using .SimulationTesting
-
 # inertia matrix
 inertia = [
     45000 -300 300
@@ -47,7 +43,7 @@ println("Begin simulation!")
 
 println("Completed!")
 
-@test SimulationTesting.quaternion_constraint(simdata.quaternion)
+@test Evaluation.quaternion_constraint(simdata.quaternion)
 
 fig1 = PlotRecipe.angularvelocities(time, simdata.angularvelocity)
 display(fig1)


### PR DESCRIPTION
* Implement `Evaluation.jl` as a submodule of `FlexibleSpacecraft.jl`
* This feature is adopted from the test function
* This PR closes #67 